### PR TITLE
One jump host

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,9 +60,30 @@ provider "remote" {
 
 - `conn` (Block List, Max: 1) Default connection to host where files are located. Can be overridden in resources and data sources. (see [below for nested schema](#nestedblock--conn))
 - `max_sessions` (Number) Maximum number of open sessions in each host connection. Defaults to `3`.
+- `proxy_conn` (Block List, Max: 1) Connection to proxy host from which to start other connections. Cannot be overridden in resources and data sources. (see [below for nested schema](#nestedblock--proxy_conn))
 
 <a id="nestedblock--conn"></a>
 ### Nested Schema for `conn`
+
+Required:
+
+- `host` (String) The remote host.
+- `user` (String) The user on the remote host.
+
+Optional:
+
+- `agent` (Boolean) Use a local SSH agent to login to the remote host. Defaults to `false`.
+- `password` (String, Sensitive) The pasword for the user on the remote host.
+- `port` (Number) The ssh port on the remote host. Defaults to `22`.
+- `private_key` (String, Sensitive) The private key used to login to the remote host.
+- `private_key_env_var` (String) The name of the local environment variable containing the private key used to login to the remote host.
+- `private_key_path` (String) The local path to the private key used to login to the remote host.
+- `sudo` (Boolean) Use sudo to gain access to file. Defaults to `false`.
+- `timeout` (Number) The maximum amount of time, in milliseconds, for the TCP connection to establish. Timeout of zero means no timeout.
+
+
+<a id="nestedblock--proxy_conn"></a>
+### Nested Schema for `proxy_conn`
 
 Required:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,12 @@ provider "remote" {
     password = "password"
     sudo     = true
   }
+
+  proxy_conn {
+    host     = "192.168.0.1"
+    user     = "gateway"
+    password = "password"
+  }
 }
 ```
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -29,4 +29,10 @@ provider "remote" {
     password = "password"
     sudo     = true
   }
+
+  proxy_conn {
+    host     = "192.168.0.1"
+    user     = "gateway"
+    password = "password"
+  }
 }

--- a/internal/provider/connection.go
+++ b/internal/provider/connection.go
@@ -84,6 +84,16 @@ func ConnectionFromResourceData(ctx context.Context, d *schema.ResourceData) (st
 	return connFromResourceData("conn.0", ctx, d)
 }
 
+func ProxyConnectionFromResourceData(ctx context.Context, d *schema.ResourceData) (string, *ssh.ClientConfig, error) {
+	_, ok := d.GetOk("proxy_conn")
+	if !ok {
+		// Not having a proxy connection is alright
+		return "", nil, nil
+	}
+
+	return connFromResourceData("proxy_conn.0", ctx, d)
+}
+
 func connFromResourceData(prefix string, ctx context.Context, d *schema.ResourceData) (string, *ssh.ClientConfig, error) {
 	prefixKey := func(key string) string {
 		return fmt.Sprintf("%s.%s", prefix, key)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -46,6 +46,14 @@ func New(version string) func() *schema.Provider {
 					Description: "Default connection to host where files are located. Can be overridden in resources and data sources.",
 					Elem:        connectionSchemaResource,
 				},
+				"proxy_conn": {
+					Type:        schema.TypeList,
+					MinItems:    0,
+					MaxItems:    1,
+					Optional:    true,
+					Description: "Connection to proxy host from which to start other connections. Cannot be overridden in resources and data sources.",
+					Elem:        connectionSchemaResource,
+				},
 				"max_sessions": {
 					Type:        schema.TypeInt,
 					Optional:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -164,6 +164,14 @@ func setResourceID(d *schema.ResourceData, conn *schema.ResourceData) {
 		conn.Get("conn.0.host").(string),
 		conn.Get("conn.0.port").(int),
 		d.Get("path").(string))
+
+	proxy_host := resourceStringWithDefault(conn, "proxy_conn.0.host", "")
+	proxy_port := resourceIntWithDefault(conn, "proxy_conn.0.port", "")
+
+	if proxy_host != "" && proxy_port != "" {
+		id = fmt.Sprintf("%s:%s|%s", proxy_host, proxy_port, id)
+	}
+
 	d.SetId(id)
 }
 
@@ -176,7 +184,15 @@ func resourceConnectionHash(d *schema.ResourceData) string {
 		resourceStringWithDefault(d, "conn.0.private_key", ""),
 		resourceStringWithDefault(d, "conn.0.private_key_path", ""),
 		strconv.FormatBool(d.Get("conn.0.agent").(bool)),
+		resourceStringWithDefault(d, "proxy_conn.0.host", ""),
+		resourceStringWithDefault(d, "proxy_conn.0.user", ""),
+		resourceIntWithDefault(d, "proxy_conn.0.port", ""),
+		resourceStringWithDefault(d, "proxy_conn.0.password", ""),
+		resourceStringWithDefault(d, "proxy_conn.0.private_key", ""),
+		resourceStringWithDefault(d, "proxy_conn.0.private_key_path", ""),
+		resourceStringWithDefault(d, "proxy_conn.0.agent", ""),
 	}
+
 	return strings.Join(elements, "::")
 }
 
@@ -184,6 +200,14 @@ func resourceStringWithDefault(d *schema.ResourceData, key string, defaultValue 
 	str, ok := d.GetOk(key)
 	if ok {
 		return str.(string)
+	}
+	return defaultValue
+}
+
+func resourceIntWithDefault(d *schema.ResourceData, key string, defaultValue string) string {
+	integer, ok := d.GetOk(key)
+	if ok {
+		return strconv.Itoa(integer.(int))
 	}
 	return defaultValue
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -141,6 +141,16 @@ func remoteClientFromResourceData(ctx context.Context, d *schema.ResourceData) (
 	if err != nil {
 		return nil, err
 	}
+
+	proxyHost, proxyClientConfig, err := ProxyConnectionFromResourceData(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	if proxyHost != "" && proxyClientConfig != nil {
+		return NewRemoteProxyClient(host, clientConfig, proxyHost, proxyClientConfig)
+	}
+
 	return NewRemoteClient(host, clientConfig)
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -47,6 +47,54 @@ var providerFactories = map[string]func() (*schema.Provider, error){
 		}
 		return provider, nil
 	},
+	"remotehost-through-nonexistent": func() (*schema.Provider, error) {
+		provider := New("dev")()
+		configureProvider := provider.ConfigureContextFunc
+		provider.ConfigureContextFunc = func(c context.Context, rd *schema.ResourceData) (interface{}, diag.Diagnostics) {
+			rd.Set("conn", []interface{}{
+				map[string]interface{}{
+					"host":     "remotehost",
+					"user":     "root",
+					"password": "password",
+					"port":     1022,
+				},
+			})
+			rd.Set("proxy_conn", []interface{}{
+				map[string]interface{}{
+					"host":     "nonexistent",
+					"user":     "root",
+					"password": "password",
+					"port":     22,
+				},
+			})
+			return configureProvider(c, rd)
+		}
+		return provider, nil
+	},
+	"remotehost-through-remotehost2": func() (*schema.Provider, error) {
+		provider := New("dev")()
+		configureProvider := provider.ConfigureContextFunc
+		provider.ConfigureContextFunc = func(c context.Context, rd *schema.ResourceData) (interface{}, diag.Diagnostics) {
+			rd.Set("conn", []interface{}{
+				map[string]interface{}{
+					"host":     "remotehost",
+					"user":     "root",
+					"password": "password",
+					"port":     1022,
+				},
+			})
+			rd.Set("proxy_conn", []interface{}{
+				map[string]interface{}{
+					"host":     "remotehost2",
+					"user":     "root",
+					"password": "password",
+					"port":     22,
+				},
+			})
+			return configureProvider(c, rd)
+		}
+		return provider, nil
+	},
 }
 
 func TestProvider(t *testing.T) {

--- a/internal/provider/resource_remote_file_test.go
+++ b/internal/provider/resource_remote_file_test.go
@@ -193,3 +193,27 @@ func TestAccResourceRemoteFileOwnershipNames(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceRemoteFileThroughProxy(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "remote_file" "resource_8" {
+					provider = remotehost-through-remotehost2
+
+					path = "/tmp/resource_8.txt"
+					content = "resource_8"
+					permissions = "0777"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"remote_file.resource_8", "content", regexp.MustCompile("resource_8")),
+				),
+			},
+		},
+	})
+}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache \
         sudo \
     && ssh-keygen -A \
     && sed -i "s/#\?PermitRootLogin.*/PermitRootLogin yes/" /etc/ssh/sshd_config \
+    && sed -i "s/#\?AllowTcpForwarding.*/AllowTcpForwarding yes/" /etc/ssh/sshd_config \
     && cp /etc/ssh/sshd_config /etc/ssh/sshd_config_unexposed \
     && sed -i "s/^#\?Port.*/Port 1022/" /etc/ssh/sshd_config_unexposed \
     && adduser -D bob \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,10 +8,12 @@ RUN apk add --no-cache \
         sudo \
     && ssh-keygen -A \
     && sed -i "s/#\?PermitRootLogin.*/PermitRootLogin yes/" /etc/ssh/sshd_config \
+    && cp /etc/ssh/sshd_config /etc/ssh/sshd_config_unexposed \
+    && sed -i "s/^#\?Port.*/Port 1022/" /etc/ssh/sshd_config_unexposed \
     && adduser -D bob \
     && echo "root:password" | chpasswd \
     && echo "bob:pwd" | chpasswd \
     && chmod 600 /root/.ssh/authorized_keys
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D"]
+CMD ["bash", "-c", "/usr/sbin/sshd -D & /usr/sbin/sshd -f /etc/ssh/sshd_config_unexposed -D"]


### PR DESCRIPTION
TODO:

- [ ] How to verify better that the jump host is actually used since the tests are run in Docker and the container has access to the other port I added too.
- [ ] Are the connections closed correctly?
- [ ] ~~Test overriding of options, I didn't verify that here.~~ Let's not go that path.
- [ ] ~~Consider different schema for block `proxy_conn`, e.g. `proxy_conn {}` on resource file tells it to not use a proxy host at all?~~